### PR TITLE
Feat: enabling manual trigger & installing GCC dependency

### DIFF
--- a/.github/workflows/go_tests.yml
+++ b/.github/workflows/go_tests.yml
@@ -29,6 +29,7 @@ on:
     branches: ['master', 'release-*']
     tags: 'v*'
     paths: ['sdks/go/pkg/**']
+  workflow_dispatch:
 
 jobs:
   build:
@@ -40,6 +41,8 @@ jobs:
       - uses: actions/setup-go@v2
         with:
           go-version: '1.16'
+      - name: Installing GCC
+        run: "sudo apt-get install build-essential -y"
       - name: Delete old coverage
         run: "cd sdks/go/pkg && rm -rf .coverage || :"
       - name: Run coverage


### PR DESCRIPTION
### What does this PR do?
It fixes the "gcc executable file not found in path" error when running go_tests on self-hosted by installing the compiler, also enables the option to trigger the test manually.

### Why is this important?
The GCC compiler is needed for the test to run properly

### Where should the reviewer start?
/.github/workflows/go_tests.yml

### How should this be manually tested?
Trigger the test manually and have a self-hosted runner configured

### Any background context you want to provide?
N/A

### What are the relevant tickets?
N/A

### Screenshots
### Questions
### Type of change
- [x]  Bug fix (non-breaking change which fixes an issue)
- [ ]  New feature (non-breaking change which adds functionality)
- [ ]  Breaking change (fix or feature that would cause existing functionality to change)

Checklist
- [ ] I have added necessary documentation (if appropriate)
- [x] I did review existing Pull Requests before submitting mine
- [ ] I have added tests that prove my fix is effective or that my feature works