### PR TITLE
Adding windows-server-2019 tag

### DIFF
--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -213,13 +213,16 @@ jobs:
         os_python: [
           {"os": [self-hosted, ubuntu-20.04], "python": "cp36-* cp37-* cp38-*"},
           {"os": [macos-latest], "python": "cp36-* cp37-* cp38-*"},
-          {"os": [windows-latest], "python": "cp36-* cp37-* cp38-*"},
+          {"os": [self-hosted,windows-server-2019], "python": "cp36-* cp37-* cp38-*"},
         ]
         arch: [auto]
         include:
           - os_python: {"os": [self-hosted, ubuntu-20.04], "python": "cp36-* cp37-* cp38-*"}
             arch: aarch64
     steps:
+    - name: Clean wheels folder (Windows)
+      if: contains(matrix.os_python.os, 'windows-server-2019')
+      run: if ((Test-Path C:\actionsDir\_work\beam\beam\apache-beam-source\wheelhouse)) { Get-ChildItem -Path C:\actionsDir\_work\beam\beam\apache-beam-source\wheelhouse -Include *.* -File -Recurse | foreach { $_.Delete()}}
     - name: Download python source distribution from artifacts
       uses: actions/download-artifact@v2
       with:
@@ -294,7 +297,7 @@ jobs:
     if: needs.check_gcp_variables.outputs.gcp-variables-set == 'true' && github.event_name != 'pull_request'
     strategy:
       matrix:
-        os : [[self-hosted, ubuntu-20.04], macos-latest, windows-latest]
+        os : [[self-hosted, ubuntu-20.04], macos-latest, [self-hosted,windows-server-2019]]
     steps:
     - name: Download wheels from artifacts
       uses: actions/download-artifact@v2

--- a/.github/workflows/java_tests.yml
+++ b/.github/workflows/java_tests.yml
@@ -65,7 +65,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [[self-hosted, ubuntu-20.04], macos-latest, windows-latest]
+        os: [[self-hosted, ubuntu-20.04], macos-latest, [self-hosted,windows-server-2019]]
     steps:
       - name: Clean GitHub workspace
         if: contains(matrix.os, 'ubuntu-20.04')
@@ -127,7 +127,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [[self-hosted, ubuntu-20.04], macos-latest, windows-latest]
+        os: [[self-hosted, ubuntu-20.04], macos-latest, [self-hosted,windows-server-2019]]
     steps:
       - name: Clean GitHub workspace
         if: contains(matrix.os, 'ubuntu-20.04')
@@ -177,7 +177,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [[self-hosted, ubuntu-20.04], macos-latest, windows-latest]
+        os: [[self-hosted, ubuntu-20.04], macos-latest, [self-hosted,windows-server-2019]]
     steps:
       - name: Clean GitHub workspace
         if: contains(matrix.os, 'ubuntu-20.04')

--- a/.github/workflows/python_tests.yml
+++ b/.github/workflows/python_tests.yml
@@ -126,7 +126,7 @@ jobs:
         run: tox -c tox.ini -e ${{ matrix.params.tox_env }}
         # Commented by the moment to run memory&cpu resources.
       - name: Run tests basic windows
-        if: startsWith(matrix.os, 'windows-server-2019')
+        if: contains(matrix.os, 'windows-server-2019')
         working-directory: ./sdks/python
         run: tox -c tox.ini -e ${{ matrix.params.tox_env }}-win
       - name: Upload test logs

--- a/.github/workflows/python_tests.yml
+++ b/.github/workflows/python_tests.yml
@@ -98,7 +98,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [[self-hosted, ubuntu-20.04], macos-latest, windows-latest]
+        os: [[self-hosted, ubuntu-20.04], macos-latest, [self-hosted,windows-server-2019]]
         params: [
           {"py_ver": "3.6", "tox_env": "py36"},
           {"py_ver": "3.7", "tox_env": "py37"},
@@ -126,7 +126,7 @@ jobs:
         run: tox -c tox.ini -e ${{ matrix.params.tox_env }}
         # Commented by the moment to run memory&cpu resources.
       - name: Run tests basic windows
-        if: startsWith(matrix.os, 'windows')
+        if: startsWith(matrix.os, 'windows-server-2019')
         working-directory: ./sdks/python
         run: tox -c tox.ini -e ${{ matrix.params.tox_env }}-win
       - name: Upload test logs
@@ -142,7 +142,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [[self-hosted, ubuntu-20.04], macos-latest, windows-latest]
+        os: [[self-hosted, ubuntu-20.04], macos-latest, [self-hosted,windows-server-2019]]
         python: [3.6, 3.7, 3.8, 3.9]
     steps:
       - name: Clean GitHub workspace
@@ -173,7 +173,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [[self-hosted, ubuntu-20.04], macos-latest, windows-latest]
+        os: [[self-hosted, ubuntu-20.04], macos-latest, [self-hosted,windows-server-2019]]
         python: [3.6, 3.7, 3.8, 3.9]
     steps:
       - name: Clean GitHub workspace


### PR DESCRIPTION
### What does this PR do?
Updates the "runs-on" tag of java_tests, python_tests and build_wheels.yml in order to execute on self-hosted for Windows, there is also an additional step for build_wheels that cleans the folder wheelhouse, fixing some issues with the existing .whl files.

### Why is this important?
It is necessary for the final migration in where all the tags will be updated to run on self-hosted.
Where should the reviewer start?
.github/workflows: python_test.yml, java_tests.yml and build_wheels.yml.

### How should this be manually tested?
Recreate a new instance-template by replacing the "windows-runner-repo" and "windows-runner-token" secrets in the gcloud command located inside .github/dockerized-gh-actions-runners/self-hosted-windows.

New secrets must be linked with the test repo.

Wait for the automatic registration process to finish and once you see the self-hosted runners listed in your repo you can launch a workflow that should be now redirected to your self-hosted.

### Any background context you want to provide?
N/A

### What are the relevant tickets?
N/A

### Type of change
 

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x]  Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
- [ ]  I have added necessary documentation (if appropriate)
- [x]  I did review existing Pull Requests before submitting mine
- [ ]  I have added tests that prove my fix is effective or that my feature works