### PR TITLE
Beam 13058 k8s apis upgrade es

### DIFF
--- a/.test-infra/kubernetes/README.md
+++ b/.test-infra/kubernetes/README.md
@@ -1,0 +1,44 @@
+<!--
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+-->
+## Kubernetes
+This folder contains resources required for some tests to deploy Kubernetes objects.
+
+Most of the files are deployed and used by automated Beam Performance Tests in Jenkins, which also takes responsability of removing those after the process is finished
+
+
+### Clusters Specification
+
+#### io-datastores
+* GKE Version: 1.22.6-gke.300
+* Node Pool Version: 1.22.6-gke.300
+* Runtime: Container-Optimized OS with containerd (cos_containerd)
+* Authentication method: OAuth Client Certificate.
+
+
+
+### Note: Basic Auth is not supported on BEAM Clusters as of March 4th 2022
+
+Prior to v1.19 GKE allowed to log into a cluster using basic authentication methods, which relies on a username and password, and now it is deprecated.
+
+Currently, OAuth is the standard authentication method, previous usernames and passwords were removed so only the certificate remains as master auth.
+
+Some Beam Performance tests need to be logged into the cluster so they can create its own resources, the correct method to do so is by setting up the right Kubeconfig inside the worker and execute get credentials within GCP.
+
+In the future if you need to create an automatic process that need to have access to the cluster, use OAuth inside your script or job.
+

--- a/.test-infra/kubernetes/elasticsearch/LargeProductionCluster/es-services-deployments.yaml
+++ b/.test-infra/kubernetes/elasticsearch/LargeProductionCluster/es-services-deployments.yaml
@@ -1,3 +1,4 @@
+
 #    Licensed to the Apache Software Foundation (ASF) under one or more
 #    contributor license agreements.  See the NOTICE file distributed with
 #    this work for additional information regarding copyright ownership.
@@ -33,33 +34,32 @@ spec:
     protocol: TCP
 ---
 # The Kubernetes deployment script for Elasticsearch master nodes.
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: es-master
   labels:
     component: elasticsearch
-    role: master
+    role: master 
 spec:
+  selector:
+    matchLabels:
+      component: elasticsearch
+      role: master
   replicas: 3
   template:
     metadata:
       labels:
         component: elasticsearch
         role: master
-      annotations:
-        pod.beta.kubernetes.io/init-containers: '[
-          {
-          "name": "sysctl",
-            "image": "busybox",
-            "imagePullPolicy": "IfNotPresent",
-            "command": ["sysctl", "-w", "vm.max_map_count=262144"],
-            "securityContext": {
-              "privileged": true
-            }
-          }
-        ]'
     spec:
+      initContainers:
+      - name: sysctl
+        image: "busybox"
+        imagePullPolicy: IfNotPresent
+        command: ["sysctl", "-w", "vm.max_map_count=262144"]
+        securityContext:
+          privileged: true
       containers:
       - name: es-master
         securityContext:
@@ -108,7 +108,7 @@ spec:
             name: "storage"
 ---
 # Kubernetes deployment script for Elasticsearch client nodes (aka load balancing proxies).
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: es-client
@@ -116,6 +116,10 @@ metadata:
     component: elasticsearch
     role: client
 spec:
+  selector:
+    matchLabels:
+      component: elasticsearch
+      role: client
   # The no. of replicas can be incremented based on the client usage using HTTP API.
   replicas: 1
   template:
@@ -123,23 +127,14 @@ spec:
       labels:
         component: elasticsearch
         role: client
-      annotations:
-      # Elasticsearch uses a hybrid mmapfs / niofs directory by default to store its indices.
-      # The default operating system limits on mmap counts is likely to be too low, which may result
-      # in out of memory exceptions. Therefore, the need to increase virtual memory
-      # vm.max_map_count for large amount of data in the pod initialization annotation.
-        pod.beta.kubernetes.io/init-containers: '[
-          {
-          "name": "sysctl",
-            "image": "busybox",
-            "imagePullPolicy": "IfNotPresent",
-            "command": ["sysctl", "-w", "vm.max_map_count=262144"],
-            "securityContext": {
-              "privileged": true
-            }
-          }
-        ]'
     spec:
+      initContainers:
+      - name: "sysctl"
+        image: busybox
+        imagePullPolicy: IfNotPresent
+        command: ["sysctl", "-w", "vm.max_map_count=262144"]
+        securityContext:
+          privileged: true
       containers:
       - name: es-client
         securityContext:
@@ -187,7 +182,7 @@ spec:
             name: "storage"
 ---
 # Kubernetes deployment script for Elasticsearch data nodes which store and index data.
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: es-data
@@ -195,25 +190,24 @@ metadata:
     component: elasticsearch
     role: data
 spec:
+  selector:
+    matchLabels:
+      component: elasticsearch
+      role: data
   replicas: 2
   template:
     metadata:
       labels:
         component: elasticsearch
         role: data
-      annotations:
-        pod.beta.kubernetes.io/init-containers: '[
-          {
-          "name": "sysctl",
-            "image": "busybox",
-            "imagePullPolicy": "IfNotPresent",
-            "command": ["sysctl", "-w", "vm.max_map_count=1048575"],
-            "securityContext": {
-              "privileged": true
-            }
-          }
-        ]'
     spec:
+      initContainers:
+      - name: "sysctl"
+        image: busybox 
+        imagePullPolicy: IfNotPresent
+        command: ["sysctl", "-w", "vm.max_map_count=1048575"]
+        securityContext: 
+          privileged: true
       containers:
       - name: es-data
         securityContext:

--- a/.test-infra/kubernetes/elasticsearch/SmallITCluster/elasticsearch-svc-rc.yaml
+++ b/.test-infra/kubernetes/elasticsearch/SmallITCluster/elasticsearch-svc-rc.yaml
@@ -35,31 +35,29 @@ spec:
 ---
 # The Kubernetes deployment script for Elasticsearch replication nodes. It will create 1 node cluster.
 # To scale the cluster as desired, you can create replicas of node use 'kubectl scale --replicas=3 rc es' command
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: es
   labels:
     component: elasticsearch
 spec:
+  selector:
+    matchLabels: 
+      component: elasticsearch
   replicas: 1
   template:
     metadata:
       labels:
-        component: elasticsearch
-      annotations:
-        pod.beta.kubernetes.io/init-containers: '[
-          {
-          "name": "sysctl",
-            "image": "busybox",
-            "imagePullPolicy": "IfNotPresent",
-            "command": ["sysctl", "-w", "vm.max_map_count=262144"],
-            "securityContext": {
-              "privileged": true
-            }
-          }
-        ]'
+        component: elasticsearch     
     spec:
+      initContainers: 
+      - name: "sysctl"
+        image: busybox 
+        imagePullPolicy: IfNotPresent
+        command: ["sysctl", "-w", "vm.max_map_count=262144"]
+        securityContext: 
+          privileged: true
       containers:
       - name: es
         securityContext:
@@ -92,5 +90,9 @@ spec:
         - mountPath: /data
           name: storage
       volumes:
+      - name: storage
+        emptyDir: {}
+
+
       - name: storage
         emptyDir: {}

--- a/.test-infra/metrics/README.md
+++ b/.test-infra/metrics/README.md
@@ -105,12 +105,24 @@ these volumes. (List volumes via `docker volume ls`)
 
 ## Kubernetes setup
 
-### Cluster Specification:
-  GKE Version: 1.20.12
-  Runtime: Containerd
-  Authenticaction method: OAuth Client Certificate.
-  
+### Cluster Specification
+* Name: metrics
+* GKE Version: 1.22.6-gke.300
+* Node Pool Version: 1.22.6-gke.300
+* Runtime: Container-Optimized OS with containerd (cos_containerd)
+* Authentication method: OAuth Client Certificate.
 
 Kubernetes deployment instructions are maintained in the wiki:
 * [Community metrics](https://cwiki.apache.org/confluence/display/BEAM/Community+Metrics)
 * [Test Results Monitoring](https://cwiki.apache.org/confluence/display/BEAM/Test+Results+Monitoring)
+
+
+### Note: Basic Auth is not supported on BEAM Clusters as of March 4th 2022
+
+Prior to v1.19 GKE allowed to log into a cluster using basic authentication methods, which relies on a username and password, and now it is deprecated.
+
+Currently, OAuth is the standard authentication method, previous usernames and passwords were removed so only the certificate remains as master auth.
+
+Some Beam Performance tests need to be logged into the cluster so they can create its own resources, the correct method to do so is by setting up the right Kubeconfig inside the worker and execute get credentials within GCP.
+
+In the future if you need to create an automatic process that need to have access to the cluster, use OAuth inside your script or job.

--- a/.test-infra/metrics/README.md
+++ b/.test-infra/metrics/README.md
@@ -106,8 +106,8 @@ these volumes. (List volumes via `docker volume ls`)
 ## Kubernetes setup
 
 ### Cluster Specification:
-  GKE Version: 1.18.20
-  Runtime: Docker
+  GKE Version: 1.20.12
+  Runtime: Containerd
   Authenticaction method: OAuth Client Certificate.
   
 

--- a/.test-infra/metrics/README.md
+++ b/.test-infra/metrics/README.md
@@ -105,6 +105,12 @@ these volumes. (List volumes via `docker volume ls`)
 
 ## Kubernetes setup
 
+### Cluster Specification:
+  GKE Version: 1.18.20
+  Runtime: Docker
+  Authenticaction method: OAuth Client Certificate.
+  
+
 Kubernetes deployment instructions are maintained in the wiki:
 * [Community metrics](https://cwiki.apache.org/confluence/display/BEAM/Community+Metrics)
 * [Test Results Monitoring](https://cwiki.apache.org/confluence/display/BEAM/Test+Results+Monitoring)

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/spanner/SpannerConfig.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/spanner/SpannerConfig.java
@@ -148,58 +148,78 @@ public abstract class SpannerConfig implements Serializable {
     public abstract SpannerConfig build();
   }
 
+  /** Specifies the Cloud Spanner project ID. */
   public SpannerConfig withProjectId(ValueProvider<String> projectId) {
     return toBuilder().setProjectId(projectId).build();
   }
 
+  /** Specifies the Cloud Spanner project ID. */
   public SpannerConfig withProjectId(String projectId) {
     return withProjectId(ValueProvider.StaticValueProvider.of(projectId));
   }
 
+  /** Specifies the Cloud Spanner instance ID. */
   public SpannerConfig withInstanceId(ValueProvider<String> instanceId) {
     return toBuilder().setInstanceId(instanceId).build();
   }
 
+  /** Specifies the Cloud Spanner instance ID. */
   public SpannerConfig withInstanceId(String instanceId) {
     return withInstanceId(ValueProvider.StaticValueProvider.of(instanceId));
   }
 
+  /** Specifies the Cloud Spanner database ID. */
   public SpannerConfig withDatabaseId(ValueProvider<String> databaseId) {
     return toBuilder().setDatabaseId(databaseId).build();
   }
 
+  /** Specifies the Cloud Spanner database ID. */
   public SpannerConfig withDatabaseId(String databaseId) {
     return withDatabaseId(ValueProvider.StaticValueProvider.of(databaseId));
   }
 
+  /** Specifies the Cloud Spanner host. */
   public SpannerConfig withHost(ValueProvider<String> host) {
     return toBuilder().setHost(host).build();
   }
 
+  /** Specifies the Cloud Spanner host, when an emulator is used. */
   public SpannerConfig withEmulatorHost(ValueProvider<String> emulatorHost) {
     return toBuilder().setEmulatorHost(emulatorHost).build();
   }
 
+  /**
+   * Specifies whether a local channel provider should be used. This should be set to True when an
+   * emulator is used.
+   */
   public SpannerConfig withIsLocalChannelProvider(ValueProvider<Boolean> isLocalChannelProvider) {
     return toBuilder().setIsLocalChannelProvider(isLocalChannelProvider).build();
   }
 
+  /** Specifies the commit deadline. This is overridden if the CommitRetrySettings is specified. */
   public SpannerConfig withCommitDeadline(Duration commitDeadline) {
     return withCommitDeadline(ValueProvider.StaticValueProvider.of(commitDeadline));
   }
 
+  /** Specifies the commit deadline. This is overridden if the CommitRetrySettings is specified. */
   public SpannerConfig withCommitDeadline(ValueProvider<Duration> commitDeadline) {
     return toBuilder().setCommitDeadline(commitDeadline).build();
   }
 
+  /** Specifies the maximum cumulative backoff. */
   public SpannerConfig withMaxCumulativeBackoff(Duration maxCumulativeBackoff) {
     return withMaxCumulativeBackoff(ValueProvider.StaticValueProvider.of(maxCumulativeBackoff));
   }
 
+  /** Specifies the maximum cumulative backoff. */
   public SpannerConfig withMaxCumulativeBackoff(ValueProvider<Duration> maxCumulativeBackoff) {
     return toBuilder().setMaxCumulativeBackoff(maxCumulativeBackoff).build();
   }
 
+  /**
+   * Specifies the ExecuteStreamingSql retry settings. If not set, the default timeout is set to 2
+   * hours.
+   */
   public SpannerConfig withExecuteStreamingSqlRetrySettings(
       RetrySettings executeStreamingSqlRetrySettings) {
     return toBuilder()
@@ -207,23 +227,28 @@ public abstract class SpannerConfig implements Serializable {
         .build();
   }
 
+  /** Specifies the commit retry settings. Setting this overrides the commit deadline. */
   public SpannerConfig withCommitRetrySettings(RetrySettings commitRetrySettings) {
     return toBuilder().setCommitRetrySettings(commitRetrySettings).build();
   }
 
+  /** Specifies the errors that will be retried by the client library for all operations. */
   public SpannerConfig withRetryableCodes(ImmutableSet<Code> retryableCodes) {
     return toBuilder().setRetryableCodes(retryableCodes).build();
   }
 
+  /** Specifies the service factory to create instance of Spanner. */
   @VisibleForTesting
   SpannerConfig withServiceFactory(ServiceFactory<Spanner, SpannerOptions> serviceFactory) {
     return toBuilder().setServiceFactory(serviceFactory).build();
   }
 
+  /** Specifies the RPC priority. */
   public SpannerConfig withRpcPriority(RpcPriority rpcPriority) {
     return withRpcPriority(ValueProvider.StaticValueProvider.of(rpcPriority));
   }
 
+  /** Specifies the RPC priority. */
   public SpannerConfig withRpcPriority(ValueProvider<RpcPriority> rpcPriority) {
     return toBuilder().setRpcPriority(rpcPriority).build();
   }


### PR DESCRIPTION
### What does this PR do?

Removes the old syntax for initContainers on the following files, it also adds the selector field where required:
• es-services-deployments.yaml
• elasticsearch-svc-rc.yaml

### Why is this important?

Starting from v1.22 Kubernetes will remove support for beta APIs, so the new syntax is required for using apps/v1 inside those deployment files.

### How should this be manually tested?

Authenticate to the respective test cluster and apply the changes via Kubectl, the new files should work also for GKE 1.22+.  
Validation tests should be run in order to test that the new initContainer feature is working properly.

### Any background context you want to provide?
N/A

### What are the relevant tickets?
N/A

### Type of change

- [ ]  Bug fix (non-breaking change which fixes an issue)
- [ ]  New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
### Checklist
 
- [x] I have added necessary documentation (if appropriate)
- [x]  I did review existing Pull Requests before submitting mine
- [ ]  I have added tests that prove my fix is effective or that my feature works