### PR TITLE
Fixing pages issue

### DIFF
--- a/.github/gh-actions-self-hosted-runners/helper-functions/monitorRunnersStatus/index.js
+++ b/.github/gh-actions-self-hosted-runners/helper-functions/monitorRunnersStatus/index.js
@@ -40,7 +40,8 @@ async function monitorRunnerStatus() {
         });
 
         let runners = await octokit.request(`GET /orgs/${process.env.ORG}/actions/runners`, {
-            org: process.env.ORG
+            org: process.env.ORG,
+            per_page: 100,
         });
 
 


### PR DESCRIPTION
Without an explicit definition, the API only returned 30 elements per page, which caused wrong runners metrics reports, I'm setting it to 100 which in combination with a daily clean up of offline runners should be enough to avoid future errors.