### PR TITLE
Switching trigger to pull_request

### DIFF
--- a/.github/workflows/build_playground_frontend.yml
+++ b/.github/workflows/build_playground_frontend.yml
@@ -43,8 +43,6 @@ jobs:
     steps:
       - name: Check out the repo
         uses: actions/checkout@v3
-        with:
-          ref: ${{ github.event.pull_request.head.sha }}
       - name: Set up Java
         uses: actions/setup-java@v3
         with:

--- a/.github/workflows/build_playground_frontend.yml
+++ b/.github/workflows/build_playground_frontend.yml
@@ -19,11 +19,11 @@ on:
   push:
     tags: ['v*']
     branches: ['master', 'release-*']
-  pull_request_target:
+  pull_request:
     paths: ['playground/backend/**']
     branches: ['playground-staging']
   workflow_dispatch:
-permissions: read-all
+
 # This allows a subsequently queued workflow run to interrupt previous runs
 concurrency:
   group: '${{ github.workflow }} @ ${{ github.event.pull_request.head.label || github.head_ref || github.ref }}'


### PR DESCRIPTION
## Describe your changes

The initial set of workflows for BEAM-12812 doesn’t need to have pull_request_target as a trigger, there is an ongoing conversation to have a consensus about future tests that might require it, in the meanwhile, we are switching back to pull_request and removing the token restrictions.



## Issue ticket number and link

[Issue 21106](https://github.com/apache/beam/issues/21106)