### PR TITLE
Switching trigger to pull_request

### DIFF
--- a/.github/workflows/go_tests.yml
+++ b/.github/workflows/go_tests.yml
@@ -42,7 +42,6 @@ jobs:
         uses: actions/checkout@v3
         with:
           fetch-depth: 2
-          ref: ${{ github.event.pull_request.head.sha }}
       - uses: actions/setup-go@v3
         with:
           go-version: '1.18'

--- a/.github/workflows/go_tests.yml
+++ b/.github/workflows/go_tests.yml
@@ -25,11 +25,10 @@ on:
   push:
     branches: ['master', 'release-*']
     tags: ['v*']
-  pull_request_target:
+  pull_request:
     branches: ['master', 'release-*']
     tags: ['v*']
     paths: ['sdks/go/pkg/**', 'sdks/go.mod', 'sdks/go.sum']
-permissions: read-all
 # This allows a subsequently queued workflow run to interrupt previous runs
 concurrency:
   group: '${{ github.workflow }} @ ${{ github.event.pull_request.head.label || github.head_ref || github.ref }}'


### PR DESCRIPTION
## Describe your changes

The initial set of workflows for BEAM-12812 don’t need to have pull_request_target as a trigger, there is an ongoing conversation to have a consensus about future tests that might require it, in the meanwhile, we are switching back to pull_request and removing the token restrictions.



## Issue ticket number and link

[Issue 21106](https://github.com/apache/beam/issues/21106)