### PR TITLE
Switching trigger to pull_request

### DIFF
--- a/.github/workflows/playground_deploy_examples.yml
+++ b/.github/workflows/playground_deploy_examples.yml
@@ -15,7 +15,7 @@
 
 name: Collect And Deploy Playground Examples
 on:
-  pull_request_target:
+  pull_request:
     types:
       - closed
     branches: ['master']
@@ -25,7 +25,7 @@ env:
   BEAM_VERSION: 2.40.0
   K8S_NAMESPACE: playground-backend
   HELM_APP_NAME: playground-backend
-permissions: read-all
+
 jobs:
   check_examples:
     name: Check examples

--- a/.github/workflows/playground_deploy_examples.yml
+++ b/.github/workflows/playground_deploy_examples.yml
@@ -37,7 +37,6 @@ jobs:
         uses: actions/checkout@v3
         with:
           fetch-depth: 0
-          ref: ${{ github.event.pull_request.head.sha }}
       - uses: actions/setup-python@v4
         with:
           python-version: '3.8'
@@ -75,8 +74,6 @@ jobs:
     steps:
       - name: Check out the repo
         uses: actions/checkout@v3
-        with:
-          ref: ${{ github.event.pull_request.head.sha }}
       - uses: actions/setup-python@v4
         with:
           python-version: '3.8'


### PR DESCRIPTION
## Describe your changes

The initial set of workflows for BEAM-12812 don’t need to have pull_request_target as a trigger, there is an ongoing conversation to have a consensus about future tests that might require it, in the meanwhile, we are switching back to pull_request and removing the token restrictions.



## Issue ticket number and link

[Issue 21106](https://github.com/apache/beam/issues/21106)