### PR TITLE
Switching trigger to pull_request

### DIFF
--- a/.github/workflows/python_tests.yml
+++ b/.github/workflows/python_tests.yml
@@ -23,7 +23,7 @@ on:
   push:
     branches: ['master', 'release-*']
     tags: ['v*']
-  pull_request_target:
+  pull_request:
     branches: ['master', 'release-*']
     tags: ['v*']
     paths: ['sdks/python/**', 'model/**']
@@ -33,7 +33,7 @@ on:
         description: 'Type "true" if you want to run Dataflow tests (GCP variables must be configured, check CI.md)'
         default: 'false'
         required: false
-permissions: read-all
+
 # This allows a subsequently queued workflow run to interrupt previous runs
 concurrency:
   group: '${{ github.workflow }} @ ${{ github.event.pull_request.head.label || github.head_ref || github.ref }}'

--- a/.github/workflows/python_tests.yml
+++ b/.github/workflows/python_tests.yml
@@ -48,8 +48,6 @@ jobs:
     steps:
       - name: Check out code
         uses: actions/checkout@v3
-        with:
-          ref: ${{ github.event.pull_request.head.sha }}
       - name: "Check are GCP variables set"
         run: "./scripts/ci/ci_check_are_gcp_variables_set.sh"
         id: check_gcp_variables
@@ -74,8 +72,6 @@ jobs:
     steps:
       - name: Check out code
         uses: actions/checkout@v3
-        with:
-          ref: ${{ github.event.pull_request.head.sha }}
       - name: Install python
         uses: actions/setup-python@v4
         with:
@@ -110,8 +106,6 @@ jobs:
     steps:
       - name: Check out code
         uses: actions/checkout@v3
-        with:
-          ref: ${{ github.event.pull_request.head.sha }}
       - name: Install python
         uses: actions/setup-python@v4
         with:
@@ -147,8 +141,6 @@ jobs:
     steps:
       - name: Check out code
         uses: actions/checkout@v3
-        with:
-          ref: ${{ github.event.pull_request.head.sha }}
       - name: Install python
         uses: actions/setup-python@v4
         with:
@@ -177,8 +169,6 @@ jobs:
     steps:
       - name: Check out code
         uses: actions/checkout@v3
-        with:
-          ref: ${{ github.event.pull_request.head.sha }}
       - name: Install python
         uses: actions/setup-python@v4
         with:


### PR DESCRIPTION
## Describe your changes

The initial set of workflows for BEAM-12812 don’t need to have pull_request_target as a trigger, there is an ongoing conversation to have a consensus about future tests that might require it, in the meanwhile, we are switching back to pull_request and removing the token restrictions.



## Issue ticket number and link

[Issue 21106](https://github.com/apache/beam/issues/21106)