### PR TITLE
Switching trigger to pull_request

### DIFF
--- a/.github/workflows/typescript_tests.yml
+++ b/.github/workflows/typescript_tests.yml
@@ -49,7 +49,6 @@ jobs:
         with:
           persist-credentials: false
           submodules: recursive
-          ref: ${{ github.event.pull_request.head.sha }}
       - name: Install node
         uses: actions/setup-node@v3
         with:
@@ -78,7 +77,6 @@ jobs:
         with:
           persist-credentials: false
           submodules: recursive
-          ref: ${{ github.event.pull_request.head.sha }}
       - name: Install Node
         uses: actions/setup-node@v3
         with:

--- a/.github/workflows/typescript_tests.yml
+++ b/.github/workflows/typescript_tests.yml
@@ -26,11 +26,11 @@ on:
   push:
     branches: ['master', 'release-*', 'javascript']
     tags: ['v*']
-  pull_request_target:
+  pull_request:
     branches: ['master', 'release-*', 'javascript']
     tags: ['v*']
     paths: ['sdks/typescript/**']
-permissions: read-all
+
 # This allows a subsequently queued workflow run to interrupt previous runs
 concurrency:
   group: '${{ github.workflow }} @ ${{ github.event.pull_request.head.label || github.head_ref || github.ref }}'


### PR DESCRIPTION
## Describe your changes

The initial set of workflows for BEAM-12812 don’t need to have pull_request_target as a trigger, there is an ongoing conversation to have a consensus about future tests that might require it, in the meanwhile, we are switching back to pull_request and removing the token restrictions.



## Issue ticket number and link

[Issue 21106](https://github.com/apache/beam/issues/21106)