### PR TITLE
Switching trigger to pull_request

### DIFF
--- a/.github/workflows/build_playground_backend.yml
+++ b/.github/workflows/build_playground_backend.yml
@@ -19,11 +19,10 @@ on:
   push:
     tags: ['v*']
     branches: ['master', 'release-*']
-  pull_request_target:
+  pull_request:
     paths: ['playground/backend/**']
     branches: ['playground-staging']
   workflow_dispatch:
-permissions: read-all
 jobs:
   build_playground_backend_docker_image:
     name: Build Playground Backend App

--- a/.github/workflows/build_playground_frontend.yml
+++ b/.github/workflows/build_playground_frontend.yml
@@ -19,11 +19,10 @@ on:
   push:
     tags: ['v*']
     branches: ['master', 'release-*']
-  pull_request_target:
+  pull_request:
     paths: ['playground/backend/**']
     branches: ['playground-staging']
   workflow_dispatch:
-permissions: read-all
 jobs:
   build_playground_frontend_docker_image:
     name: Build Playground Frontend App

--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -25,14 +25,13 @@ on:
   push:
     branches: ['master', 'release-*']
     tags: ['v*']
-  pull_request_target:
+  pull_request:
     branches: ['master', 'release-*']
     tags: ['v*']
     paths: ['sdks/python/**', 'model/**', 'release/**']
   workflow_dispatch:
 env:
   GCP_PATH: "gs://${{ secrets.GCP_PYTHON_WHEELS_BUCKET }}/${GITHUB_REF##*/}/${GITHUB_SHA}-${GITHUB_RUN_ID}/"
-permissions: read-all
 jobs:
 
   check_gcp_variables:

--- a/.github/workflows/go_tests.yml
+++ b/.github/workflows/go_tests.yml
@@ -25,11 +25,10 @@ on:
   push:
     branches: ['master', 'release-*']
     tags: ['v*']
-  pull_request_target:
+  pull_request:
     branches: ['master', 'release-*']
     tags: ['v*']
     paths: ['sdks/go/pkg/**', 'sdks/go.mod', 'sdks/go.sum']
-permissions: read-all
 jobs:
   build:
     runs-on: [self-hosted, ubuntu-20.04]

--- a/.github/workflows/java_tests.yml
+++ b/.github/workflows/java_tests.yml
@@ -30,12 +30,11 @@ on:
   push:
     branches: ['master', 'release-*']
     tags: ['v*']
-  pull_request_target:
+  pull_request:
     branches: ['master', 'release-*']
     tags: ['v*']
     paths: ['sdks/java/**', 'model/**', 'runners/**', 'examples/java/**',
             'examples/kotlin/**', 'release/**', 'buildSrc/**']
-permissions: read-all
 jobs:
   check_gcp_variables:
     timeout-minutes: 5

--- a/.github/workflows/local_env_tests.yml
+++ b/.github/workflows/local_env_tests.yml
@@ -23,11 +23,10 @@ on:
   push:
     branches: ['master', 'release-*']
     tags: ['v*']
-  pull_request_target:
+  pull_request:
     branches: ['master', 'release-*']
     tags: ['v*']
     paths: ['dev-support/**', 'buildSrc/**', '**/build.gradle', 'sdks/python/setup.py', 'sdks/python/tox.ini']
-permissions: read-all
 jobs:
   run_local_env_install_ubuntu:
     timeout-minutes: 25

--- a/.github/workflows/playground_deploy_examples.yml
+++ b/.github/workflows/playground_deploy_examples.yml
@@ -15,7 +15,7 @@
 
 name: Collect And Deploy Playground Examples
 on:
-  pull_request_target:
+  pull_request:
     types:
       - closed
     branches: ['master']
@@ -25,7 +25,6 @@ env:
   BEAM_VERSION: 2.33.0
   K8S_NAMESPACE: playground-backend
   HELM_APP_NAME: playground-backend
-permissions: read-all
 jobs:
   check_examples:
     name: Check examples

--- a/.github/workflows/pr-bot-pr-updates.yml
+++ b/.github/workflows/pr-bot-pr-updates.yml
@@ -18,7 +18,6 @@ on:
   pull_request_target:
     types: ["synchronize"] # Synchronize is the action that runs after pushes to the user branch
   issue_comment:
-permissions: read-all
 jobs:
   process-pr-update:
     # Give GITHUB_TOKEN permissions to write pull request comments and to the state branch, and read PR related info

--- a/.github/workflows/python_tests.yml
+++ b/.github/workflows/python_tests.yml
@@ -23,7 +23,7 @@ on:
   push:
     branches: ['master', 'release-*']
     tags: ['v*']
-  pull_request_target:
+  pull_request:
     branches: ['master', 'release-*']
     tags: ['v*']
     paths: ['sdks/python/**', 'model/**']
@@ -33,7 +33,6 @@ on:
         description: 'Type "true" if you want to run Dataflow tests (GCP variables must be configured, check CI.md)'
         default: 'false'
         required: true
-permissions: read-all
 jobs:
   check_gcp_variables:
     timeout-minutes: 5

--- a/.github/workflows/typescript_tests.yml
+++ b/.github/workflows/typescript_tests.yml
@@ -26,11 +26,10 @@ on:
   push:
     branches: ['master', 'release-*', 'javascript']
     tags: ['v*']
-  pull_request_target:
+  pull_request:
     branches: ['master', 'release-*', 'javascript']
     tags: ['v*']
     paths: ['sdks/typescript/**']
-permissions: read-all
 jobs:
   typescript_unit_tests:
     name: 'TypeScript Unit Tests'


### PR DESCRIPTION
## Describe your changes

The initial set of workflows for BEAM-12812 doesn’t need to have pull_request_target as a trigger, there is an ongoing conversation to have a consensus about future tests that might require it, in the meanwhile, we are switching back to pull_request and removing the token restrictions.



## Issue ticket number and link

[Issue 21106](https://github.com/apache/beam/issues/21106)